### PR TITLE
use new Fields syntax, simplify docvalue_fields creation

### DIFF
--- a/x-pack/legacy/plugins/maps/public/layers/sources/es_search_source/es_search_source.js
+++ b/x-pack/legacy/plugins/maps/public/layers/sources/es_search_source/es_search_source.js
@@ -176,7 +176,7 @@ export class ESSearchSource extends AbstractESSource {
     });
   }
 
-  // Returns docvalue_field for the union of indexPattern's dateFields and request's field names.
+  // Returns docvalue_fields array for the union of indexPattern's dateFields and request's field names.
   async _getDateDocvalueFields(searchFields) {
     const dateFieldNames = _.map(await this.getDateFields(), 'name');
     return searchFields

--- a/x-pack/legacy/plugins/maps/public/layers/sources/es_source.js
+++ b/x-pack/legacy/plugins/maps/public/layers/sources/es_source.js
@@ -323,7 +323,7 @@ export class AbstractESSource extends AbstractVectorSource {
       return null;
     }
 
-    const fieldFromIndexPattern = indexPattern.fields.byName[rawFieldName];
+    const fieldFromIndexPattern = indexPattern.fields.getByName(rawFieldName);
     if (!fieldFromIndexPattern) {
       return null;
     }

--- a/x-pack/legacy/plugins/maps/public/layers/sources/vector_source.js
+++ b/x-pack/legacy/plugins/maps/public/layers/sources/vector_source.js
@@ -80,7 +80,7 @@ export class AbstractVectorSource extends AbstractSource {
     return null;
   }
 
-  async getTimeFields() {
+  async getDateFields() {
     return [];
   }
 

--- a/x-pack/legacy/plugins/maps/public/layers/styles/vector_style.js
+++ b/x-pack/legacy/plugins/maps/public/layers/styles/vector_style.js
@@ -395,10 +395,7 @@ export class VectorStyle extends AbstractStyle {
 
       for (let j = 0; j < styleFields.length; j++) {
         const { supportsFeatureState, isScaled, name, range, computedName } = styleFields[j];
-        //Date fields pulled from doc_values is an array
-        const value = Array.isArray(feature.properties[name])
-          ? parseFloat(feature.properties[name][0])
-          : parseFloat(feature.properties[name]);
+        const value = parseFloat(feature.properties[name]);
         let styleValue;
         if (isScaled) {
           if (isNaN(value) || !range) {//cannot scale

--- a/x-pack/legacy/plugins/maps/public/layers/vector_layer.js
+++ b/x-pack/legacy/plugins/maps/public/layers/vector_layer.js
@@ -254,7 +254,7 @@ export class VectorLayer extends AbstractLayer {
   }
 
   async getOrdinalFields() {
-    const timeFields = await this._source.getTimeFields();
+    const timeFields = await this._source.getDateFields();
     const timeFieldOptions = timeFields.map(({ label, name }) => {
       return {
         label,


### PR DESCRIPTION
clean-up to Nick's PR

* https://github.com/elastic/kibana/pull/47921 changed indexPattern fields API
* avoid requesting all date fields from index pattern in docvalue_fields
* Move date docvalue_fields creation into function
* do not put any source specific logic in VectorStyle